### PR TITLE
Turning off VueCLI preload and prefetch.

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -62,8 +62,8 @@ module.exports = {
     }
   },
   chainWebpack(config) {
-    // config.plugins.delete('preload') // TODO: need test
-    // config.plugins.delete('prefetch') // TODO: need test
+    config.plugins.delete('preload') // TODO: need test
+    config.plugins.delete('prefetch') // TODO: need test
 
     // set svg-sprite-loader
     config.module.rule('svg').exclude.add(resolve('src/icons')).end()


### PR DESCRIPTION
These two will cause the build to inject preload and prefetch scripts, but also injected the runtime.js which is not built to the static JS folder.